### PR TITLE
feat: implement support for wandb, fixed seed for unconditional train…

### DIFF
--- a/conf/lora/lora.yml
+++ b/conf/lora/lora.yml
@@ -2,6 +2,7 @@ $include:
   - conf/vampnet.yml
 
 fine_tune: True
+wandb: True
 
 train/AudioDataset.n_examples: 100000000
 val/AudioDataset.n_examples: 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ loralib
 wavebeat @ git+https://github.com/hugofloresgarcia/wavebeat
 lac @ git+https://github.com/hugofloresgarcia/lac.git
 descript-audiotools @ git+https://github.com/descriptinc/audiotools.git@0.7.2
+wandb


### PR DESCRIPTION
- adds wandb logging for all relevant training parameters 
- logs generated audio files to wandb after each step (could maybe be a lot, i just went with the defaults they implemented -> but we can reduce that in the future)
- after each step logs unconditional generated audio with a fixed seed

